### PR TITLE
Clear pmSerial buffer before each AQI read to avoid buffer overflows leading to bad checksums.

### DIFF
--- a/pm25_display/pm25_display.ino
+++ b/pm25_display/pm25_display.ino
@@ -53,9 +53,19 @@ void loop() {
 }
 
 void readAqiSensor() {
+  // Clear the serial buffer.
+  while (pmSerial.available()) {
+    pmSerial.read();
+  }
+
+  // Wait for a reading.
+  unsigned long start_ms = millis();
   PM25_AQI_Data data;
-  if (aqiSensor.read(&data)) {
-    aqi = {data.pm25_standard, millis()};
+  while (millis() - start_ms < seconds(2)) {
+    if (aqiSensor.read(&data)) {
+      aqi = {data.pm25_standard, millis()};
+      break;
+    }
   }
 }
 


### PR DESCRIPTION
I noticed that AQI readings would fail somewhat frequently, sometimes consecutively for minutes at a time. Looks like this is because the AQI sensor is spitting out 32 byte payloads every second-ish, but the SoftwareSerial has a buffer of only 64 bytes and we were only consuming them every 5 seconds, meaning we were constantly hitting buffer overflows. This meant we'd end up with overlapping payloads in the buffer and the checksum wouldn't match (good guy checksum doing its job):
```
11:02:52.347 -> Got full buffer: 42 4D 0 1C 0 2 0 3 0 3 0 2 0 3 0 3 1 A1 0 78 42 4D 0 1C 0 2 0 3 0 3 0 2 
11:02:52.347 -> read failed: BAD CHECKSUM!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```
Note that payloads start with `42 4D`, and we've got a `42 4D` plopped in the middle there.

Consuming the `pmSerial` buffer before each read clears room for a new full payload to arrive, eliminating the overlaps. This means we wait for each new reading rather than parsing the reading that's already waiting in our buffer (ie. it takes a little longer), but has the benefit that the `atMillis` timestamps are a little more accurate.